### PR TITLE
require Node.js v14 and NPM v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/NordicSemiconductor/modemtalk#readme",
   "engines": {
-    "node": ">=10.0.0",
-    "npm": ">=6.0.0"
+    "node": ">=14.0.0",
+    "npm": ">=8.0.0"
   },
   "dependencies": {
     "mcc-mnc-list": "^1.1.1",


### PR DESCRIPTION
BREAKING CHANGE: this changes the required Node.js version to 14 and NPM to v8